### PR TITLE
fix the edge case of a 1 term component

### DIFF
--- a/src/sgd2.hpp
+++ b/src/sgd2.hpp
@@ -158,8 +158,13 @@ std::vector<std::vector<uint64_t>> build_graph_unweighted(uint64_t n, uint64_t m
 std::vector<term> bfs(uint64_t n, uint64_t m, uint64_t* I, uint64_t* J)
 {
     auto graph = build_graph_unweighted(n, m, I, J);
-
-    uint64_t nC2 = (n*(n-1))/2;
+        
+    uint64_t nC2;
+    if (n == 1) {
+        nC2 = 1;
+    } else {
+        nC2 = (n*(n-1))/2;
+    }
     std::vector<term> terms;
     terms.reserve(nC2);
 


### PR DESCRIPTION
This fixes the issues when running the `odgi layout` algorithm with graphs, that have components which consist of only one term. Example failure command line:
```
odgi layout -i SARS-CoV-2.genbank.20200329.complete+annotations.odgi -o SARSCoV2.genbank.20200329.complete+annotations.odgi.svg
```
GDB gives:
```
Program received signal SIGSEGV, Segmentation fault.
0x000055555580df7b in sgd2::schedule (terms=..., t_max=30, eps=0.01)
    at /usr/include/c++/10.1.0/bits/stl_vector.h:1061
1061	      operator[](size_type __n) const _GLIBCXX_NOEXCEPT
```

[SARS-CoV-2.genbank.20200329.complete+annotations.odgi.txt](https://github.com/ekg/sgd2/files/4890289/SARS-CoV-2.genbank.20200329.complete%2Bannotations.odgi.txt)

Once this PR is in, we can update `odgi`.