### PR TITLE
Replace uses of deprecated std::random_shuffle

### DIFF
--- a/src/sgd2.hpp
+++ b/src/sgd2.hpp
@@ -89,11 +89,14 @@ std::vector<term_sparse> MSSP_weighted(const std::vector<std::vector<edge>>& gra
 
 void sgd(double* X, std::vector<term> &terms, const std::vector<double> &etas, double delta)
 {
+    std::random_device rd;
+    std::mt19937 rg(rd());
+
     // iterate through step sizes
     for (double eta : etas)
     {
         // shuffle terms
-        std::random_shuffle(terms.begin(), terms.end());
+        std::shuffle(terms.begin(), terms.end(), rg);
 
         double Delta_max = 0;
         for (const term &t : terms)
@@ -459,11 +462,14 @@ void mds_direct(uint64_t n, double* X, double* d, double* w, uint64_t t_max, dou
 
 void sgd(double* X, std::vector<term_sparse> &terms, const std::vector<double> &etas)
 {
+    std::random_device rd;
+    std::mt19937 rg(rd());
+
     // iterate through step sizes
     for (double eta : etas)
     {
         // shuffle terms
-        std::random_shuffle(terms.begin(), terms.end());
+        std::shuffle(terms.begin(), terms.end(), rg);
 
         for (const term_sparse& t : terms)
         {


### PR DESCRIPTION
It appears `std::random_shuffle` was deprecated in C++14 and removed in C++17. It was replaced with [`std::shuffle`](https://en.cppreference.com/w/cpp/algorithm/random_shuffle), which is very similar but takes a (required) explicit RNG parameter. (This came up for me when building odgi with clang—yep, cf https://github.com/pangenome/odgi/pull/350 again. This is my last in the flurry of PRs from that exercise, though!)

I've replaced these calls in the most trivial possible way: initializing a Mersenne twister RNG at the top of the `sgd` function (in both cases) and using it for the `shuffle` call. There may be performance reasons to initialize the RNG elsewhere, but this at least seems to "work," so there's that.

Let me know if you'd like me to dig deeper to find a better place to put these things. Or to consider less inscrutable variable names than `rd` and `rg`. 🤪 